### PR TITLE
[BUGFIX] Fix composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": ">=9.5.0 <11",
-		"friendsofphp/php-cs-fixer": "^2.17",
-		"typo3/coding-standards": "^0.2.0"
+		"typo3/cms-core": ">=9.5.0 <11"
 	},
 	"require-dev": {
-		"nimut/testing-framework": "^5"
+		"friendsofphp/php-cs-fixer": "^2.17",
+		"nimut/testing-framework": "^5",
+		"typo3/coding-standards": "^0.2.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Move the packages php-cs-fixer and coding-standards from requirements into dev-requirement. This change allows us to use our own version of this packages in projects.