### PR TITLE
[BUGFIX] Fix parameter order in implode function

### DIFF
--- a/Classes/Utility/HreflangTags.php
+++ b/Classes/Utility/HreflangTags.php
@@ -187,7 +187,7 @@ class HreflangTags implements LoggerAwareInterface
                 }
             }
             sort($this->renderedListItems);
-            $this->renderedList = "\n" . implode($this->renderedListItems, "\n") . "\n";
+            $this->renderedList = "\n" . implode("\n", $this->renderedListItems) . "\n";
         }
 
         $this->renderedList = $content . $this->renderedList;


### PR DESCRIPTION
Change the ordering of parameter in implode function.

See: https://www.php.net/manual/en/function.implode.php

#17 