### PR TITLE
[BUGFIX] Avoid unnecessary page cache clearing

### DIFF
--- a/Classes/Utility/HreflangTags.php
+++ b/Classes/Utility/HreflangTags.php
@@ -365,9 +365,6 @@ class HreflangTags implements LoggerAwareInterface
             $tags = array_map(function ($value) {
                 return 'pageId_' . $value;
             }, array_keys($relations));
-            if (!empty($tags)) {
-                $this->getCacheManager()->flushCachesInGroupByTags('pages', $tags);
-            }
             $this->getCacheInstance()->set((string)$cacheIdentifier, $relations, $tags, 84000);
         }
 


### PR DESCRIPTION
Fix a bug where this extension would clear the page and pagesection 
cache of all related pages, during the rendering of the hreflang tags.
The caches will still be cleared if records get modified in the backend.